### PR TITLE
Adjust window box for GTK HeaderBar

### DIFF
--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -67,10 +67,10 @@ def _moveResizeWindow(handle: EwmhWindow, newBox: Box):
     _net_extents = handle._getNetFrameExtents()
     _gtk_extents = handle._getGtkFrameExtents()
     if _net_extents and len(_net_extents) >= 4:
-        # this means it has no GTK HeaderBar
+        # seems that top left includes window borders, but width and height does not
         newLeft = newBox.left
         newTop = newBox.top
-        newWidth = newBox.width
+        newWidth = newBox.width - int(_net_extents[0]) - int(_net_extents[1])
         newHeight = newBox.height - int(_net_extents[2]) - int(_net_extents[3])
     elif _gtk_extents and len(_gtk_extents) >= 4:
         newLeft = newBox.left - _gtk_extents[0]

--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -37,17 +37,28 @@ def _getWindowBox(handle: EwmhWindow) -> Box:
     #   in that case, we add the title bar to get the right box
 
     _net_extents = handle._getNetFrameExtents()
-    if _net_extents and len(_net_extents) >= 4:  # this means it has no GTK HeaderBar
+    _gtk_extents = handle._getGtkFrameExtents()
+    if _net_extents and len(_net_extents) >= 4:
+        # this means it has no GTK HeaderBar
         x = pos.x - int(_net_extents[0])
         y = pos.y - int(_net_extents[2])
         w = geom.width + int(_net_extents[0]) + int(_net_extents[1])
         h = geom.height + int(_net_extents[2]) + int(_net_extents[3])
-    else:
+    elif _gtk_extents and len(_gtk_extents) >= 4:
+        # this means there is a GTK HeaderBar
         _gtk_extents = handle._getGtkFrameExtents()
         x = pos.x + int(_gtk_extents[0])
         y = pos.y + int(_gtk_extents[2])
         w = geom.width - int(_gtk_extents[0]) - int(_gtk_extents[1])
         h = geom.height - int(_gtk_extents[2]) - int(_gtk_extents[3])
+    else:
+        # something else: best guess is to trust pos and geom from above
+        # NOTE: if you have this case and are not getting the expected result,
+        #   please open an issue: https://github.com/Kalmat/PyWinBox/issues/new
+        x = pos.x
+        y = pos.y
+        w = geom.width
+        h = geom.height
     return Box(x, y, w, h)
 
 

--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -30,7 +30,7 @@ def _getWindowBox(handle: EwmhWindow) -> Box:
     # check if application uses special title bar (a.k.a. GTK HeaderBar)
     # see: https://docs.gtk.org/gtk4/class.HeaderBar.html
     # if it has HeaderBar (e.g., gedit):
-    #   top left will be top left including extra space GTK
+    #   top left will be top left including extra space (shadows?)
     #   in that case, we subtract gtk extents to the right box
     # if it doesn't (e.g., gvim):
     #   top left will be top left of client window (i.e., excluding the title bar)

--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -47,7 +47,6 @@ def _getWindowBox(handle: EwmhWindow) -> Box:
         h = geom.height + int(_net_extents[2]) + int(_net_extents[3])
     elif _gtk_extents and len(_gtk_extents) >= 4:
         # this means there is a GTK HeaderBar
-        _gtk_extents = handle._getGtkFrameExtents()
         x = pos.x + int(_gtk_extents[0])
         y = pos.y + int(_gtk_extents[2])
         w = geom.width - int(_gtk_extents[0]) - int(_gtk_extents[1])
@@ -73,8 +72,8 @@ def _moveResizeWindow(handle: EwmhWindow, newBox: Box):
         newWidth = newBox.width - int(_net_extents[0]) - int(_net_extents[1])
         newHeight = newBox.height - int(_net_extents[2]) - int(_net_extents[3])
     elif _gtk_extents and len(_gtk_extents) >= 4:
-        newLeft = newBox.left - _gtk_extents[0]
-        newTop = newBox.top - _gtk_extents[2]
+        newLeft = newBox.left - int(_gtk_extents[0])
+        newTop = newBox.top - int(_gtk_extents[2])
         newWidth = newBox.width + int(_gtk_extents[0]) + int(_gtk_extents[1])
         newHeight = newBox.height + int(_gtk_extents[2]) + int(_gtk_extents[3])
     else:

--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -26,7 +26,29 @@ def _getWindowBox(handle: EwmhWindow) -> Box:
     # https://stackoverflow.com/questions/12775136/get-window-position-and-size-in-python-with-xlib
     geom = handle.xWindow.get_geometry()
     pos = handle.root.translate_coords(handle.id, 0, 0)
-    return Box(pos.x, pos.y, geom.width, geom.height)
+
+    # check if application uses special title bar (a.k.a. GTK HeaderBar)
+    # see: https://docs.gtk.org/gtk4/class.HeaderBar.html
+    # if it has HeaderBar (e.g., gedit):
+    #   top left will be top left including extra space GTK
+    #   in that case, we subtract gtk extents to the right box
+    # if it doesn't (e.g., gvim):
+    #   top left will be top left of client window (i.e., excluding the title bar)
+    #   in that case, we add the title bar to get the right box
+
+    _net_extents = handle._getNetFrameExtents()
+    if _net_extents and len(_net_extents) >= 4:  # this means it has no GTK HeaderBar
+        x = pos.x - int(_net_extents[0])
+        y = pos.y - int(_net_extents[2])
+        w = geom.width + int(_net_extents[0]) + int(_net_extents[1])
+        h = geom.height + int(_net_extents[2]) + int(_net_extents[3])
+    else:
+        _gtk_extents = handle._getGtkFrameExtents()
+        x = pos.x + int(_gtk_extents[0])
+        y = pos.y + int(_gtk_extents[2])
+        w = geom.width - int(_gtk_extents[0]) - int(_gtk_extents[1])
+        h = geom.height - int(_gtk_extents[2]) - int(_gtk_extents[3])
+    return Box(x, y, w, h)
 
 
 def _moveResizeWindow(handle: EwmhWindow, newBox: Box):


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/Kalmat/PyWinCtl/pull/79

This is another attempt at fixing https://github.com/Kalmat/PyWinCtl/issues/66, which still seems to be off for me.

The idea is to get the right box including the title bar / header bar in PyWinBox.

To get the correct client area (i.e., without title bar), the opposite has to be done for HeaderBar-free applications. This is done in a [separate PR](https://github.com/Kalmat/PyWinCtl/pull/79) in PyWinCtl.

So to summarize the state after these two PRs:
For applications without GTK HeaderBar
- PyWinBox gives us the tight bounding box now (excluding shadows, including title bar)
- getClientFrame in PyWinCtl will remove the title bar from PyWinBox's bounding box

For applications with GTK HeaderBar
- PyWinBox gives us the tight bounding box now (excluding shadows, including title bar)
- getClientFrame in PyWinCtl will not modify PyWinBox's bounding box

This would handle 3 of 4 cases perfectly, only getClientFrame with GTK HeaderBar still doesn't work. But it would still give a reasonable result in that case.

The test might need some more work (failed for me on master as well though). Let me know if you want me to take a stab at it. Otherwise feel free to just add to this PR.
