### PR TITLE
handle-typing

### DIFF
--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import sys
 import os
 
+from ._main import Box
+
 try:
     from typing import TypeAlias
 except Exception:
@@ -12,12 +14,15 @@ except Exception:
         from typing_extensions import TypeAlias
 from typing import Union
 
-from Xlib.xobject.drawable import Window as XWindow
-
-from ._main import Box
-from ewmhlib import EwmhWindow
-
-assert sys.platform == "linux"
+try:
+    from Xlib.xobject.drawable import Window as XWindow
+    from ewmhlib import EwmhWindow
+except Exception:
+    # This raises the OS exception
+    assert sys.platform == "linux"
+    # This raises Xlib/ewmhlib not installed exception (when OS is correct)
+    from Xlib.xobject.drawable import Window as XWindow
+    from ewmhlib import EwmhWindow
 
 
 _HandleTypeIn: TypeAlias = Union[int, XWindow, None]

--- a/src/pywinbox/_pywinbox_linux.py
+++ b/src/pywinbox/_pywinbox_linux.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import sys
+if sys.platform != "linux":
+    raise OSError(f"Cannot import {__name__} on {sys.platform}")
+
 import os
 
 from ._main import Box
 
 try:
+    # TypeAlias does not exist in typing for Python3.9
     from typing import TypeAlias
 except Exception:
     from typing import TYPE_CHECKING
@@ -14,15 +18,8 @@ except Exception:
         from typing_extensions import TypeAlias
 from typing import Union
 
-try:
-    from Xlib.xobject.drawable import Window as XWindow
-    from ewmhlib import EwmhWindow
-except Exception:
-    # This raises the OS exception
-    assert sys.platform == "linux"
-    # This raises Xlib/ewmhlib not installed exception (when OS is correct)
-    from Xlib.xobject.drawable import Window as XWindow
-    from ewmhlib import EwmhWindow
+from Xlib.xobject.drawable import Window as XWindow
+from ewmhlib import EwmhWindow
 
 
 _HandleTypeIn: TypeAlias = Union[int, XWindow, None]

--- a/src/pywinbox/_pywinbox_macos.py
+++ b/src/pywinbox/_pywinbox_macos.py
@@ -3,12 +3,16 @@
 # mypy: disable_error_code = no-any-return
 from __future__ import annotations
 
-import subprocess
 import sys
+if sys.platform != "darwin":
+    raise OSError(f"Cannot import {__name__} on {sys.platform}")
+
+import subprocess
 
 from ._main import Box
 
 try:
+    # TypeAlias does not exist in typing for Python3.9
     from typing import TypeAlias
 except Exception:
     from typing import TYPE_CHECKING
@@ -16,13 +20,7 @@ except Exception:
         from typing_extensions import TypeAlias
 from typing import NamedTuple, cast, Union
 
-try:
-    import AppKit
-except Exception:
-    # This raises the OS exception
-    assert sys.platform == "darwin"
-    # This raises AppKit not installed exception (when OS is correct)
-    import AppKit
+import AppKit
 
 
 class _macOSNSHandle(NamedTuple):

--- a/src/pywinbox/_pywinbox_macos.py
+++ b/src/pywinbox/_pywinbox_macos.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from ._main import Box
+
 try:
     from typing import TypeAlias
 except Exception:
@@ -14,10 +16,13 @@ except Exception:
         from typing_extensions import TypeAlias
 from typing import NamedTuple, cast, Union
 
-from ._main import Box
-import AppKit
-
-assert sys.platform == "darwin"
+try:
+    import AppKit
+except Exception:
+    # This raises the OS exception
+    assert sys.platform == "darwin"
+    # This raises AppKit not installed exception (when OS is correct)
+    import AppKit
 
 
 class _macOSNSHandle(NamedTuple):

--- a/src/pywinbox/_pywinbox_win.py
+++ b/src/pywinbox/_pywinbox_win.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import sys
 
+import ctypes
+
+from ._main import Box
+
 try:
     from typing import TypeAlias
 except Exception:
@@ -11,12 +15,13 @@ except Exception:
         from typing_extensions import TypeAlias
 from typing import Union
 
-import ctypes
-import win32gui
-
-from ._main import Box
-
-assert sys.platform == "win32"
+try:
+    import win32gui
+except Exception:
+    # This raises the OS exception
+    assert sys.platform == "win32"
+    # This raises win32gui not installed exception (when OS is correct)
+    import win32gui
 
 
 # Thanks to poipoiPIO (https://github.com/poipoiPIO) for his HELP!!!

--- a/src/pywinbox/_pywinbox_win.py
+++ b/src/pywinbox/_pywinbox_win.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import sys
+if sys.platform != "win32":
+    raise OSError(f"Cannot import {__name__} on {sys.platform}")
 
 import ctypes
 
 from ._main import Box
 
 try:
+    # TypeAlias does not exist in typing for Python3.9
     from typing import TypeAlias
 except Exception:
     from typing import TYPE_CHECKING
@@ -15,13 +18,7 @@ except Exception:
         from typing_extensions import TypeAlias
 from typing import Union
 
-try:
-    import win32gui
-except Exception:
-    # This raises the OS exception
-    assert sys.platform == "win32"
-    # This raises win32gui not installed exception (when OS is correct)
-    import win32gui
+import win32gui
 
 
 # Thanks to poipoiPIO (https://github.com/poipoiPIO) for his HELP!!!


### PR DESCRIPTION
This is my attempt to propery type `handle` variable. Not sure if it is right.

Apart from this, you changed this:

```
if sys.platform != "linux":
    raise OSError(f"Cannot import {__name__} on {sys.platform}")
```

by this:

`assert sys.platform == "linux"`

but I had to revert it back because of ruff complaining: `import not at top of the file`